### PR TITLE
chore(commits): add max length arg to the action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ $(VIRTUAL_ENV): setup.cfg setup.py dev-requirements.txt requirements.txt
 
 lint: check_format check_imports check_types check_pylint
 
+format:
+	$(VIRTUAL_ENV)/bin/black changelog_generator tests
+
 check_types: $(VIRTUAL_ENV)
 	$(VIRTUAL_ENV)/bin/mypy changelog_generator
 
@@ -27,4 +30,4 @@ tests: $(VIRTUAL_ENV)
 clean:
 	rm -fr build/ dist/ .eggs/ changelog_generator.egg-info/
 
-.PHONY: lint check_format check_types tests clean
+.PHONY: lint check_format check_types tests clean format

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_PREFIX: # add a prefix here if you have a `prefix/semver` pattern in your repo
+          MAX_LENGTH: # max_length for the changelog, once above sections will be cutted to avoid crash. Defaults to 5000.
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/changelog_generator/changelog_template.jinja
+++ b/changelog_generator/changelog_template.jinja
@@ -10,3 +10,6 @@
     {%- endif %}
   {% endfor -%}
 {% endfor -%}
+
+{% if %}
+**Full changelog**: [changelog since {{previous_tag}}]({{link_to_commits}})

--- a/changelog_generator/commit.py
+++ b/changelog_generator/commit.py
@@ -1,5 +1,6 @@
 import re
-from typing import List, Optional
+from typing import List, Optional, Sequence
+from dataclasses import dataclass
 
 re_header_pattern = re.compile(
     r"^(?P<type>[^\(]+)\((?P<scope>[^\)]+)\): (?P<subject>.+)$"
@@ -74,3 +75,123 @@ class Commit:
         self.get_header_data()
         self.get_revert_data()
         self.get_jira_data()
+
+
+@dataclass
+class CommitTree:
+    id: str
+    commit_type: str
+    commits: Sequence[Commit]
+
+
+def get_commit_from_type(
+    commits: Sequence[Commit], commit_type: str
+) -> Sequence[Commit]:
+    return sorted(
+        filter(lambda commit: commit.commit_type == commit_type, commits),
+        key=lambda commit: commit.scope,
+    )
+
+
+def get_commit_but_types(
+    commits: Sequence[Commit], commit_types: Sequence[str]
+) -> Sequence[Commit]:
+    return sorted(
+        filter(
+            lambda commit: commit.commit_type
+            and commit.commit_type not in commit_types,
+            commits,
+        ),
+        key=lambda commit: commit.scope,
+    )
+
+
+def construct_commit_trees(commits: Sequence[Commit]) -> List[CommitTree]:
+    trees = []
+    documentations = CommitTree(
+        id="doc",
+        commit_type=":notebook_with_decorative_cover: Documentation",
+        commits=get_commit_from_type(commits, "docs"),
+    )
+    if documentations.commits:
+        trees.append(documentations)
+
+    features = CommitTree(
+        id="features",
+        commit_type=":rocket: Features",
+        commits=get_commit_from_type(commits, "feat"),
+    )
+    if features.commits:
+        trees.append(features)
+
+    fixes = CommitTree(
+        id="fixes",
+        commit_type=":bug: Fixes",
+        commits=get_commit_from_type(commits, "fix"),
+    )
+    if fixes.commits:
+        trees.append(fixes)
+
+    reverts = CommitTree(
+        id="revert",
+        commit_type=":scream: Revert",
+        commits=get_commit_from_type(commits, "revert"),
+    )
+    if reverts.commits:
+        trees.append(reverts)
+
+    others = CommitTree(
+        id="others",
+        commit_type=":nut_and_bolt: Others",
+        commits=get_commit_but_types(
+            commits, ["documentations", "feat", "fix", "revert"]
+        ),
+    )
+    if others.commits:
+        trees.append(others)
+
+    return trees
+
+
+def cut_tree_commits(tree: CommitTree, n_keep: int, n_commits_after_cutted: int) -> int:
+
+    n_tree_commits = len(tree.commits)
+    if n_tree_commits > n_keep:
+        tree.commits = tree.commits[:n_keep]
+        n_commits_after_cutted = n_commits_after_cutted - n_tree_commits + n_keep
+    return n_commits_after_cutted
+
+
+def cut_trees_commits(
+    trees: List[CommitTree], n_commits: int, max_total_commits: int
+) -> None:
+    """
+    Cut trees commits if we are above the given threshold for a valid changelog
+    Cut them in order according to the `cut_order` map.
+    Once the number of commits in under the fixed threshold, we stop.
+    When cutting we cut the section to 10 commits (`n_commits_to_keep`).
+    """
+    cut_order = {"others": 1, "revert": 2, "doc": 3, "fixes": 4, "features": 5}
+
+    trees_to_cut: List[CommitTree] = list(
+        sorted(trees, key=lambda tree: cut_order[tree.id])
+    )
+    n_commits_after_section_cutted = n_commits
+
+    n_commits_to_keep = 10
+    for tree in trees_to_cut:
+        if n_commits_after_section_cutted > max_total_commits:
+            n_commits_after_section_cutted = cut_tree_commits(
+                tree, n_commits_to_keep, n_commits_after_section_cutted
+            )
+        else:
+            return
+
+
+def check_and_cut_if_over_limit(
+    max_changelog_length: int, n_commits: int, trees: List[CommitTree]
+) -> None:
+    # check if we have to much commits (-200 to take count of sections titles/spaces)
+    max_commits = max_changelog_length - 200
+    if n_commits > max_commits:
+        cut_trees_commits(trees, n_commits, max_commits)

--- a/changelog_generator/repository_manager.py
+++ b/changelog_generator/repository_manager.py
@@ -1,6 +1,6 @@
 import re
 from functools import lru_cache
-from typing import List, Sequence
+from typing import List, Optional, Sequence
 
 from git import Repo
 
@@ -62,3 +62,22 @@ class RepositoryManager:
             Commit(hexsha=commit.hexsha, summary=commit.summary, message=commit.message)
             for commit in self.repository.iter_commits(revision, no_merges=True)
         )
+
+    @lru_cache()
+    def get_commits_since_tag(self, tag: str) -> Sequence[Commit]:
+        revision = f"{tag}..{self.current_tag}"
+
+        return tuple(
+            Commit(hexsha=commit.hexsha, summary=commit.summary, message=commit.message)
+            for commit in self.repository.iter_commits(revision, no_merges=True)
+        )
+
+    @lru_cache()
+    def get_github_link_for_commits_since_last_tag(self) -> Optional[str]:
+        if not self.previous_tag:
+            return None
+        return self.get_github_link_for_commits_since_tag(self.previous_tag)
+
+    @lru_cache()
+    def get_github_link_for_commits_since_tag(self, tag: str) -> str:
+        return f"https://github.com/{self.organization}/{self.name}/compare/{tag}...{self.current_tag}"

--- a/tests/test_cut_trees.py
+++ b/tests/test_cut_trees.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from git import Repo
+
+from changelog_generator.commit import construct_commit_trees, cut_trees_commits
+from changelog_generator.repository_manager import RepositoryManager
+
+
+def test_repository_github_link_since_tag(core_repo: Repo) -> None:
+    # Given
+    path = str(Path(core_repo.git_dir).parent)
+    repository = RepositoryManager(path, "monolite")
+    tag = "monolite/7.5.0"
+
+    link = repository.get_github_link_for_commits_since_tag(tag)
+
+    assert (
+        link
+        == f"https://github.com/lumapps/core/compare/monolite/7.5.0...{repository.current_tag}"
+    )
+
+
+def test_cut_trees_commits(core_repo: Repo) -> None:
+    # Given
+    path = str(Path(core_repo.git_dir).parent)
+    repository = RepositoryManager(path, "monolite")
+    tag = "monolite/7.5.0"
+    commits = repository.get_commits_since_tag(tag)
+    n_commits_before_cut = len(commits)
+    trees = construct_commit_trees(commits)
+
+    max_commits = 2000
+
+    # When
+    cut_trees_commits(trees, n_commits_before_cut, max_commits)
+
+    # Then
+    n_commits_after_cut = sum([len(t.commits) for t in trees])
+
+    assert trees
+    assert n_commits_after_cut < max_commits
+
+    # Check that only others section have been cut
+    # since monolite/7.5.0 others section contains at least 2000 commits (and 2500 total)
+    # so it should be the first and only one to be cut to reach 2000 commits
+    others_commits = trees[-1]
+    assert others_commits.id == "others"
+    assert len(others_commits.commits) == 10
+    assert (
+        n_commits_after_cut - len(others_commits.commits) + 1 + max_commits
+        == n_commits_before_cut
+    )


### PR DESCRIPTION
Use max length args to cut the changelog when it goes above 
and add a link to commits compare at the end of the template.

This PR is to avoid the action crashing when the changelog is too long.
