### PR TITLE
chore(tag): modify prefix tag pattern matcher to support more cases

### DIFF
--- a/changelog_generator/tag_manager.py
+++ b/changelog_generator/tag_manager.py
@@ -78,7 +78,7 @@ class PrefixedTagManager(BaseTagManager):
     """
 
     PATTERN = re.compile(
-        r"^(?P<prefix>\w+)/(?P<major>\d+)\.(?P<minor>\d+)\.((?P<bug>\d+)|rc(?P<rc>\d+))?$"
+        r"^(?P<prefix>[\w-]+)/(?P<major>\d+)\.(?P<minor>\d+)\.((?P<bug>\d+)|rc(?P<rc>\d+))?$"
     )
 
     def __init__(self, repository: Repo, prefix: str):


### PR DESCRIPTION
Modify the prefix matcher to support -_ between words for instance analytics-web-api/2.4.4 would be correctly parsed with that (it is not today)