### PR TITLE
chore(script): add option to filter commits based on scope and tag_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_PREFIX: # add a prefix here if you have a `prefix/semver` pattern in your repo
+          FILTER_COMMITS_ON_TAG_PREFIX: # Optional: set it to true if you want to filter commits and keep only the one that have the same scope as the provided tag prefix
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/changelog_generator/__main__.py
+++ b/changelog_generator/__main__.py
@@ -53,11 +53,26 @@ def get_commit_but_types(
         key=lambda commit: commit.scope,
     )
 
+def get_commits_from_scope(
+    commits: Sequence[Commit], commit_scope: str
+) -> Sequence[Commit]:
+    return sorted(
+        filter(lambda commit: commit.scope == commit_scope, commits),
+        key=lambda commit: commit.scope,
+    )
 
 def main() -> None:
-    repository = RepositoryManager("./", os.environ.get("TAG_PREFIX"))
+    tag_prefix = os.environ.get("TAG_PREFIX")
+    repository = RepositoryManager("./", tag_prefix)
+
+    filter_commits_on_tag_prefix = os.getenv("FILTER_COMMITS_ON_TAG_PREFIX")
 
     commits = repository.commits_since_last_tag
+
+    if tag_prefix and bool(filter_commits_on_tag_prefix):
+        commits = get_commits_from_scope(commits, tag_prefix)
+
+
     trees: List[CommitTree] = []
 
     documentations = CommitTree(


### PR DESCRIPTION

This Pr aims to provide an optional way to filter commits based on matching scope with the TAG_PREFIX.

This would allow for changelog that only contains commits from said prefix but requires that all commits are correctly scoped otherwise they would not appear.

