### PR TITLE
fix(jira): the jira pattern

### DIFF
--- a/changelog_generator/commit.py
+++ b/changelog_generator/commit.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 re_header_pattern = re.compile(
     r"^(?P<type>[^\(]+)\((?P<scope>[^\)]+)\): (?P<subject>.+)$"
 )
-re_jira_pattern = re.compile(r"([A-Z]{2,4}-[0-9]{1,6})")
+re_jira_pattern = re.compile(r"\b([A-Z]{2,6}[0-9]{0,6}-[0-9]{1,6})\b")
 re_broke_pattern = re.compile(r"^BROKEN:$")
 re_revert_header_pattern = re.compile(r"^[R|r]evert:? (?P<summary>.*)$")
 re_revert_commit_pattern = re.compile(r"^This reverts commit ([a-f0-9]+)")

--- a/tests/test_jira_extraction.py
+++ b/tests/test_jira_extraction.py
@@ -1,0 +1,23 @@
+from changelog_generator.commit import Commit
+
+
+def test_no_reference():
+    commit = Commit("", "", "a commit without any reference")
+
+    assert commit.jiras == []
+
+
+def test_one_reference():
+    commit = Commit("", "", "this is a reference ABCD-1")
+
+    assert commit.jiras == ["ABCD-1"]
+
+
+def test_several_reference():
+    commit = Commit(
+        "",
+        "",
+        "valid references ABCD-1 AB-0001 FOO2-1, and not valid ones A-123 abc-145 ABC_524 ",
+    )
+
+    assert commit.jiras == ["ABCD-1", "AB-0001", "FOO2-1"]


### PR DESCRIPTION
use the same pattern than https://github.com/lumapps/commit-message-validator
