### PR TITLE
fix(gen-ai): Avoid returning results if no Vertex AI auth provided

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Github-actions-validator"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: lumapps/github-actions-validator@master
   preview_changelog:
     timeout-minutes: 30

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ changelog_generator.egg-info/
 venv/
 
 .mypy_cache/
+
+.idea

--- a/changelog_generator/ai_generator.py
+++ b/changelog_generator/ai_generator.py
@@ -32,9 +32,6 @@ SCOPES = [
 
 
 def generate_ai_summary(prefix: str| None, git_diff: str | None) -> str | None:
-    if not git_diff:
-        return "No changes were provided in the diff"
-
     project = os.getenv("VERTEX_PROJECT")
     location = os.getenv("VERTEX_LOCATION")
     model = os.getenv("VERTEX_MODEL")
@@ -56,6 +53,9 @@ def generate_ai_summary(prefix: str| None, git_diff: str | None) -> str | None:
     if not service_account_key:
         logging.error("Missing VERTEX_CREDENTIALS environment variable")
         return None
+
+    if not git_diff:
+        return "No changes were provided in the diff"
 
     credentials = service_account.Credentials.from_service_account_info(
         json.loads(service_account_key), scopes=SCOPES,


### PR DESCRIPTION
### Description
When executing for the first time diffs is empty and produces a result even though credentials are not provided.


### Solution
Move the check for diff being available after credentials checks.

### Concern
We should compute the diff properly, but for the first deploy of a service it will pull all the diffs from the impacted files from the git history which does not seem smart... Although with path filters it should get only the global/shared files.